### PR TITLE
Removing git submodule init and update for ecmd by default to support offline bitbake

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Alternatively ecmd-pdbg can be built using `meson`.
 
 Need `meson` and `ninja`. Alternatively, source an OpenBMC ARM/x86 SDK.
 ```
-meson build && ninja -C build
+meson -Dstandalone-build=enabled build && ninja -C build
 ```
 
 #### Requirements on the native (build) machine

--- a/bin/edbgWrapper.sh
+++ b/bin/edbgWrapper.sh
@@ -5,14 +5,26 @@
 # ***************************************************************************
 cmd=${0##*/}
 
-# ***************************************************************************
-# Figure out what the user's ecmd executable is set to, if they have one.
-# ***************************************************************************
-if [ ! -x "$ECMD_EXE" ]
+ECMD_EXE="/usr/bin/edbg"
+if [ -f $ECMD_EXE ]; then
+    export ECMD_EXE
+elif [ ! -x "$ECMD_EXE" ]
   then
     echo "*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****"
     echo "The eCMD executable '$ECMD_EXE' does NOT exist or is not executable"
     echo "Please modify your ECMD_EXE variable to point to a valid eCMD executable before running"
+    echo "*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****"
+    exit 1
+fi
+
+ECMD_DLL_FILE="/usr/lib/libedbg.so.0.1"
+if [ -f $ECMD_DLL_FILE ]; then
+    export ECMD_DLL_FILE
+elif [ ! -x "$ECMD_DLL_FILE" ]
+  then
+    echo "*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****"
+    echo "The eCMD dll '$ECMD_DLL_FILE' does NOT exist or is not executable"
+    echo "Please modify your ECMD_DLL_FILE variable to point to a valid eCMD dll before running"
     echo "*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****ERROR*****"
     exit 1
 fi

--- a/meson.build
+++ b/meson.build
@@ -76,20 +76,22 @@ libz    = meson.get_compiler('cpp').find_library('libz')
 libdl   = meson.get_compiler('cpp').find_library('libdl')
 libyaml = meson.get_compiler('cpp').find_library('libyaml')
 
-message('git submodule init & update of ecmd')
-rc = run_command(git, 'submodule', 'init', 'ecmd')
-if rc.returncode() != 0
-  error('git submodule init of ecmd : FAILED')
+if get_option('standalone-build').enabled()
+    message('git submodule init & update of ecmd')
+    rc = run_command(git, 'submodule', 'init', 'ecmd')
+    if rc.returncode() != 0
+      error('git submodule init of ecmd : FAILED')
+    endif
+
+    message('git submodule init of ecmd : SUCCESS')
+
+    rc = run_command(git, 'submodule', 'update', 'ecmd')
+    if rc.returncode() != 0
+      error('git submodule update of ecmd : FAILED')
+    endif
+
+    message('git submodule update of ecmd : SUCCESS')
 endif
-
-message('git submodule init of ecmd : SUCCESS')
-
-rc = run_command(git, 'submodule', 'update', 'ecmd')
-if rc.returncode() != 0
-  error('git submodule update of ecmd : FAILED')
-endif
-
-message('git submodule update of ecmd : SUCCESS')
 
 '''
 # Following piece of code to auto generate the files using custom_target doesn't
@@ -222,6 +224,7 @@ libecmd_headers = include_directories('ecmd/ecmd-core/capi',
                               'ecmd/ecmd-core/capi/sedcScomdef/',
                               autogen_path)
 
+
 # Create static lib "ecmdClientCapi"
 libecmdClientCapi = static_library(
                       'ecmdClientCapi',
@@ -251,7 +254,6 @@ libecmd = library(
             include_directories : libecmd_headers,
             version: meson.project_version(),
             install: true)
-
 
 import('pkgconfig').generate(
   name: 'libecmd',
@@ -322,7 +324,7 @@ install_data('bin/edbgWrapper.sh', install_dir : get_option('bindir'))
 # Create a soft link to edbgWrapper.sh
 link_cmd = find_program('ln')
 foreach ecmdtool : ['ecmdquery', 'getcfam', 'putcfam', 'getscom', 'putscom',
-                'getmemproc', 'putmemproc', 'stopclocks','startclocks']
+                'getmemproc', 'putmemproc', 'stopclocks','startclocks','istep']
     infile = 'bin/edbgWrapper.sh'
     outfile = ecmdtool
 
@@ -334,14 +336,14 @@ foreach ecmdtool : ['ecmdquery', 'getcfam', 'putcfam', 'getscom', 'putscom',
       install_dir : get_option('bindir'))
 endforeach
 
-
 # Installing the help text(htxt) files to '/usr/help'
 cp_cmd = find_program('cp')
 helptext_path = 'ecmd/ecmd-core/cmd/help/'
 foreach helptext : ['getscom.htxt', 'putscom.htxt', 'getcfam.htxt',
                    'putcfam.htxt', 'putmemproc.htxt', 'getmemproc.htxt',
                    'stopclocks.htxt', 'startclocks.htxt', 'ecmdquery.htxt',
-                   'getvpdkeyword.htxt','putvpdkeyword.htxt','ecmd.htxt']
+                   'getvpdkeyword.htxt','putvpdkeyword.htxt','ecmd.htxt',
+                   'istep.htxt']
     infile  = helptext_path + helptext
     outfile = helptext
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,4 @@
 option('rootprefix', type : 'string',
        description : '''override the root prefix [default: '/usr']''')
+option('standalone-build', type: 'feature',
+       description: 'Standalone build with submodules init & update')


### PR DESCRIPTION
Removing git submodule init and update for ecmd by default to support offline bitbake

Steps to enable standalone build:
1)`meson -Dstandalone-build=enabled build`
2)`ninja -C build`